### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,25 @@ rb-podcast-pos 0.2
 -------------------------------------------------------------------------------
   Edward G. Bruck <ed.bruck1@gmail.com>
 
-DESCRIPTION
+*DESCRIPTION*
 
   Save and restore podcast playing position (Rhythmbox 3.0.2)
 
-INSTALL
+*INSTALL*
 
   Copy directory to:
-    * ~/.local/share/rhythmbox/plugins
+    - ~/.local/share/rhythmbox/plugins
 
   So it looks like:
-    * ~/.local/share/rhythmbox/plugins/rb-podcast-pos
+    - ~/.local/share/rhythmbox/plugins/rb-podcast-pos
 
-DEPENDENCIES (Ubuntu 20.04 LTS)
+*DEPENDENCIES (Ubuntu 20.04 LTS)*
 
   Requires pygobject to be installed.
 
     sudo apt-get install libcairo2-dev
     pip3 install pygobject
 
-LICENSE
+*LICENSE*
 
   rb-podcast-pos is distributed under the GPL Version 2.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ rb-podcast-pos 0.2
   Edward G. Bruck <ed.bruck1@gmail.com>
 
 DESCRIPTION
-  
+
   Save and restore podcast playing position (Rhythmbox 3.0.2)
 
 INSTALL
@@ -14,6 +14,13 @@ INSTALL
 
   So it looks like:
     * ~/.local/share/rhythmbox/plugins/rb-podcast-pos
+
+DEPENDENCIES (Ubuntu 20.04 LTS)
+
+  Requires pygobject to be installed.
+
+    sudo apt-get install libcairo2-dev
+    pip3 install pygobject
 
 LICENSE
 


### PR DESCRIPTION
Spent a fair amount of time trying to get this plugin to work on Ubuntu 20.04 and Rhythmbox 3.4.4.

The good news is the plugin itself works (for the most part). I will see if I can identify an issue I'm having where position is not saved between restarts of rhythmbox. As long as I don't close rhythmbox the position is remembered.